### PR TITLE
fix: Adjust parallax image quality and placeholder handling

### DIFF
--- a/components/Landing/Parallax.vue
+++ b/components/Landing/Parallax.vue
@@ -39,8 +39,9 @@
         v-if="isPhotoPlaceholder"
         src="/images/landing/placeholder.jpeg"
         alt="Video Placeholder"
-        quality="100"
+        quality="85"
         sizes="100vw sm:100vw md:100vw lg:100vw xl:100vw xxl:100vw"
+        :placeholder="[192, 108, 75, 5]"
         class="parallax__image"
       />
     </div>
@@ -122,12 +123,11 @@ const handleScroll = () => {
 
   .parallax__image
     object-fit: cover
-    height: 100%
+    height: 100%!important
     width: 100%
     position: absolute!important
     top: 50%
     left: 50%
-    height: 100%!important
     transform: translate(-50%, -50%)
     pointer-events: none
 


### PR DESCRIPTION
- Reduced image quality from 100 to 85 for performance optimization.
- Added dynamic placeholder sizes for responsive loading.